### PR TITLE
update css for sponsors logos

### DIFF
--- a/css/lgm20.css
+++ b/css/lgm20.css
@@ -214,9 +214,19 @@ a.inwhiteklink:hover {
 .homepage {
     background-color:black;
 }
+
+.sponsors {
+    display: block;
+    margin-left: auto;
+    margin-right: auto;
+}
+
 @media (min-width: 1200px) {
    .homepage {
        height:940px;
+   }
+   .sponsors {
+    padding: 1em;
    }
 }
 
@@ -224,17 +234,26 @@ a.inwhiteklink:hover {
     .homepage {
         height:830px;
     }
+    .sponsors {
+    padding: 1em;
+   }
  }
  
  @media (min-width: 768px) and (max-width: 991px) {
     .homepage {
         height:680px;
     }
+    .sponsors {
+        padding: 1em;
+    }
  }
 
  @media (max-width: 767px) {
     .homepage {
         height:1130px;
+    }
+    .sponsors {
+        padding: 3em;
     }
  }
 

--- a/en/index.html
+++ b/en/index.html
@@ -218,24 +218,24 @@
                   <p class="mt-4">This event is targeted at artists, developers, professionnal designers or just curious people. Please consider being a partner or sponsor to support this great meeting.</p>
                 </div><!-- /col12-->
 
-                <div class="col-md-3">
-                  <p><a href="https://activdesign.eu/"><img class="img-fluid" src="../css/img/logopartner1.png" alt=""></a></p>
+                <div class="col-md-4">
+                  <p><a href="https://activdesign.eu/"><img class="img-fluid sponsors" src="../css/img/logopartner1.png" alt=""></a></p>
                 </div><!-- /col2 -->
 
-                <div class="col-md-3">
-                  <p><a href="http://www.jardinmoderne.org/"><img class="img-fluid" src="../css/img/jardinmoderne.png" alt=""></a></p>
+                <div class="col-md-4">
+                  <p><a href="http://www.jardinmoderne.org/"><img class="img-fluid sponsors" src="../css/img/jardinmoderne.png" alt=""></a></p>
                 </div><!-- /col2 -->
 
-                <div class="col-md-3">
-                  <p><a href="https://istic.univ-rennes1.fr/"><img class="img-fluid" src="../css/img/logo-istic.png" alt=""></a></p>
+                <div class="col-md-4">
+                  <p><a href="https://istic.univ-rennes1.fr/"><img class="img-fluid sponsors" src="../css/img/logo-istic.png" alt=""></a></p>
                 </div><!-- /col2 -->
 
-                <div class="col-md-3">
-                  <p><a href="https://fonts.google.com/about"><img class="img-fluid" src="../css/img/google-2.png" alt=""></a></p>
+                <div class="col-md-4">
+                  <p><a href="https://fonts.google.com/about"><img class="img-fluid sponsors" src="../css/img/google-2.png" alt=""></a></p>
                 </div><!-- /col2 -->
 
-                <div class="col-md-3">
-                  <p><a href="https://ev.kde.org/"><img class="img-fluid" src="../css/img/kde-logo-white-blue-rounded-128x128.png" alt=""></a></p>
+                <div class="col-md-4">
+                  <p><a href="https://ev.kde.org/"><img class="img-fluid sponsors" src="../css/img/kde-logo-white-blue-rounded-128x128.png" alt=""></a></p>
                 </div><!-- /col2 -->
 
                 <div class="col-md-12">

--- a/en/sponsors.html
+++ b/en/sponsors.html
@@ -104,24 +104,24 @@
                             <p class="mt-4">This event is targeted at artists, developers, professionnal designers or just curious people. Please consider being a partner or sponsor to support this great meeting.</p>
                             </div><!-- /col12-->
 
-                            <div class="col-md-3 mt-4">
-                            <p><a href="https://activdesign.eu/"><img class="img-fluid" src="../css/img/logopartner1.png" alt=""></a></p>
+                            <div class="col-md-4 mt-4">
+                            <p><a href="https://activdesign.eu/"><img class="img-fluid sponsors" src="../css/img/logopartner1.png" alt=""></a></p>
                             </div><!-- /col2 -->
 
-                            <div class="col-md-3 mt-4">
-                            <p><a href="http://www.jardinmoderne.org/"><img class="img-fluid" src="../css/img/jardinmoderne.png" alt=""></a></p>
+                            <div class="col-md-4 mt-4">
+                            <p><a href="http://www.jardinmoderne.org/"><img class="img-fluid sponsors" src="../css/img/jardinmoderne.png" alt=""></a></p>
                             </div><!-- /col2 -->
 
-                            <div class="col-md-3 mt-4">
-                            <p><a href="https://istic.univ-rennes1.fr/"><img class="img-fluid" src="../css/img/logo-istic.png" alt=""></a></p>
+                            <div class="col-md-4 mt-4">
+                            <p><a href="https://istic.univ-rennes1.fr/"><img class="img-fluid sponsors" src="../css/img/logo-istic.png" alt=""></a></p>
                             </div><!-- /col2 -->
 
-                            <div class="col-md-3 mt-4">
-                            <p><a href="https://fonts.google.com/about"><img class="img-fluid" src="../css/img/google-2.png" alt=""></a></p>
+                            <div class="col-md-4 mt-4">
+                            <p><a href="https://fonts.google.com/about"><img class="img-fluid sponsors" src="../css/img/google-2.png" alt=""></a></p>
                             </div><!-- /col2 -->
 
-                            <div class="col-md-3 mt-4">
-                            <p><a href="https://ev.kde.org/"><img class="img-fluid" src="../css/img/kde-logo-white-blue-rounded-128x128.png" alt=""></a></p>
+                            <div class="col-md-4 mt-4">
+                            <p><a href="https://ev.kde.org/"><img class="img-fluid sponsors" src="../css/img/kde-logo-white-blue-rounded-128x128.png" alt=""></a></p>
                             </div><!-- /col2 -->
                         </div><!-- /row-->
                     </div><!-- /container-->

--- a/fr/index.html
+++ b/fr/index.html
@@ -211,24 +211,24 @@
                   <p class="mt-4">Cet événement réunis aussi bien des artistes, développeurs, professionnels de l'image que de simple curieux. Si cela vous tente de devenir partenaire ou un sponsor de l'événement, entrez en contact avec nous.</p>
                 </div><!-- /col12-->
 
-                <div class="col-md-3">
-                  <p><a href="https://activdesign.eu/"><img class="img-fluid" src="../css/img/logopartner1.png" alt=""></a></p>
+                <div class="col-md-4">
+                  <p><a href="https://activdesign.eu/"><img class="img-fluid sponsors" src="../css/img/logopartner1.png" alt=""></a></p>
                 </div><!-- /col2 -->
 
-                <div class="col-md-3">
-                  <p><a href="http://www.jardinmoderne.org/"><img class="img-fluid" src="../css/img/jardinmoderne.png" alt=""></a></p>
+                <div class="col-md-4">
+                  <p><a href="http://www.jardinmoderne.org/"><img class="img-fluid sponsors" src="../css/img/jardinmoderne.png" alt=""></a></p>
                 </div><!-- /col2 -->
 
-                <div class="col-md-3">
-                  <p><a href="https://istic.univ-rennes1.fr/"><img class="img-fluid" src="../css/img/logo-istic.png" alt=""></a></p>
+                <div class="col-md-4">
+                  <p><a href="https://istic.univ-rennes1.fr/"><img class="img-fluid sponsors" src="../css/img/logo-istic.png" alt=""></a></p>
                 </div><!-- /col2 -->
 
-                <div class="col-md-3">
-                  <p><a href="https://fonts.google.com/about"><img class="img-fluid" src="../css/img/google-2.png" alt=""></a></p>
+                <div class="col-md-4">
+                  <p><a href="https://fonts.google.com/about"><img class="img-fluid sponsors" src="../css/img/google-2.png" alt=""></a></p>
                 </div><!-- /col2 -->
 
-                <div class="col-md-3">
-                  <p><a href="https://ev.kde.org/"><img class="img-fluid" src="../css/img/kde-logo-white-blue-rounded-128x128.png" alt=""></a></p>
+                <div class="col-md-4">
+                  <p><a href="https://ev.kde.org/"><img class="img-fluid sponsors" src="../css/img/kde-logo-white-blue-rounded-128x128.png" alt=""></a></p>
                 </div><!-- /col2 -->
 
                 <div class="col-md-12">


### PR DESCRIPTION
adjust the spacing of logos to comply with google requirement:
"The amount of clear space around our logo should be equal to or greater
than the height of the “G” in Google."

change to 3 logos per line as it looks better with the spacing

center images